### PR TITLE
ignore URI fragment when dereferencing

### DIFF
--- a/src/Formatter/CurlFormatter.php
+++ b/src/Formatter/CurlFormatter.php
@@ -226,8 +226,6 @@ class CurlFormatter
      */
     protected function extractUrlArgument(RequestInterface $request)
     {
-        $uri = $request->getUri();
-
-        $this->addCommandPart(escapeshellarg((string)$uri));
+        $this->addCommandPart(escapeshellarg((string)$request->getUri()->withFragment('')));
     }
 }


### PR DESCRIPTION
#14 was not the correct fix. See also guzzle/guzzle#1514