### PR TITLE
Add support for formatting large request bodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require": {
         "php": ">=5.5.0",
         "guzzlehttp/guzzle": "^6.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0",
+        "symfony/process": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.2.2"

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,13 @@
     "description": "Get the cURL shell command from a Guzzle request",
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.0",
-        "psr/log": "^1.0",
-        "symfony/process": "^3.0"
+        "guzzlehttp/guzzle": "^6.1|^7.0",
+        "guzzlehttp/psr7":"^1.7|^2.0",
+        "psr/log": "^1.0|^2.0|^3.0",
+        "symfony/process": "^3.3|^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.2.2"
+        "phpunit/phpunit": "^6|^7|^8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
         "guzzlehttp/guzzle": "^6.1|^7.0",
         "guzzlehttp/psr7":"^1.7|^2.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/process": "^3.3|^4.0|^5.0"
+        "symfony/process": "^3.3|^4.0|^5.0|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6|^7|^8"
+        "phpunit/phpunit": "^6|^7|^8|^9"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit bootstrap="vendor/autoload.php"
          colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="tests">
       <directory>tests</directory>
     </testsuite>
   </testsuites>

--- a/src/Formatter/CurlFormatter.php
+++ b/src/Formatter/CurlFormatter.php
@@ -5,6 +5,7 @@ namespace Namshi\Cuzzle\Formatter;
 use GuzzleHttp\Cookie\CookieJarInterface;
 use GuzzleHttp\Cookie\SetCookie;
 use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Process\Process;
 
 /**
  * Class CurlFormatter it formats a Guzzle request to a cURL shell command
@@ -134,7 +135,7 @@ class CurlFormatter
         if ($contents) {
             // clean input of null bytes
              $contents = str_replace(chr(0), '', $contents);
-            $this->addOption('d', escapeshellarg($contents));
+            $this->addOption('d', $this->escapeShellArgument($contents));
         }
 
         //if get request has data Add G otherwise curl will make a post request
@@ -168,7 +169,7 @@ class CurlFormatter
         }
 
         if ($values) {
-            $this->addOption('b', escapeshellarg(implode('; ', $values)));
+            $this->addOption('b', $this->escapeShellArgument(implode('; ', $values)));
         }
     }
 
@@ -183,12 +184,12 @@ class CurlFormatter
             }
 
             if ('user-agent' === strtolower($name)) {
-                $this->addOption('A', escapeshellarg($header[0]));
+                $this->addOption('A', $this->escapeShellArgument($header[0]));
                 continue;
             }
 
             foreach ((array)$header as $headerValue) {
-                $this->addOption('H', escapeshellarg("{$name}: {$headerValue}"));
+                $this->addOption('H', $this->escapeShellArgument("{$name}: {$headerValue}"));
             }
         }
     }
@@ -228,6 +229,13 @@ class CurlFormatter
      */
     protected function extractUrlArgument(RequestInterface $request)
     {
-        $this->addCommandPart(escapeshellarg((string)$request->getUri()->withFragment('')));
+        $this->addCommandPart($this->escapeShellArgument((string)$request->getUri()->withFragment('')));
+    }
+
+    protected function escapeShellArgument($argument)
+    {
+        $process = new Process([$argument]);
+        $escaped = $process->getCommandLine();
+        return $escaped;
     }
 }

--- a/tests/Client/RequestTest.php
+++ b/tests/Client/RequestTest.php
@@ -4,18 +4,19 @@ namespace Client;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
-use GuzzleHttp\Psr7;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
 use Namshi\Cuzzle\Formatter\CurlFormatter;
+use PHPUnit\Framework\TestCase;
 
-class RequestTest extends \PHPUnit_Framework_TestCase
+class RequestTest extends TestCase
 {
     /**
      * @var CurlFormatter
      */
     protected $curlFormatter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->client        = new Client();
         $this->curlFormatter = new CurlFormatter();
@@ -27,25 +28,25 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $jar = CookieJar::fromArray(['Foo' => 'Bar', 'identity' => 'xyz'], 'local.example');
         $curl    = $this->curlFormatter->format($request, ['cookies' => $jar]);
 
-        $this->assertNotContains("-H 'Host: local.example'", $curl);
-        $this->assertContains("-b 'Foo=Bar; identity=xyz'", $curl);
+        $this->assertStringNotContainsString("-H 'Host: local.example'", $curl);
+        $this->assertStringContainsString("-b 'Foo=Bar; identity=xyz'", $curl);
     }
 
     public function testPOST()
     {
-        $request = new Request('POST', 'http://local.example', [], Psr7\stream_for('foo=bar&hello=world'));
+        $request = new Request('POST', 'http://local.example', [], Utils::streamFor('foo=bar&hello=world'));
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("-d 'foo=bar&hello=world'", $curl);
+        $this->assertStringContainsString("-d 'foo=bar&hello=world'", $curl);
     }
 
     public function testPUT()
     {
-        $request = new Request('PUT', 'http://local.example', [], Psr7\stream_for('foo=bar&hello=world'));
+        $request = new Request('PUT', 'http://local.example', [], Utils::streamFor('foo=bar&hello=world'));
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("-d 'foo=bar&hello=world'", $curl);
-        $this->assertContains('-X PUT', $curl);
+        $this->assertStringContainsString("-d 'foo=bar&hello=world'", $curl);
+        $this->assertStringContainsString('-X PUT', $curl);
     }
 
     public function testDELETE()
@@ -53,7 +54,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request('DELETE', 'http://local.example');
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains('-X DELETE', $curl);
+        $this->assertStringContainsString('-X DELETE', $curl);
     }
 
     public function testHEAD()
@@ -61,7 +62,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request('HEAD', 'http://local.example');
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("curl 'http://local.example' --head", $curl);
+        $this->assertStringContainsString("curl 'http://local.example' --head", $curl);
     }
 
     public function testOPTIONS()
@@ -69,7 +70,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request('OPTIONS', 'http://local.example');
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains('-X OPTIONS', $curl);
+        $this->assertStringContainsString('-X OPTIONS', $curl);
     }
 
-} 
+}

--- a/tests/Formatter/CurlFormatterTest.php
+++ b/tests/Formatter/CurlFormatterTest.php
@@ -161,4 +161,13 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
             ],
         ];
     }
+
+    public function testLongArgument()
+    {
+        ini_set('memory_limit', -1);
+        $body  = str_repeat('A', 1024*1024*64);
+        $request = new Request('POST', 'http://example.local', [], \GuzzleHttp\Psr7\stream_for($body));
+
+        $curl = $this->curlFormatter->format($request);
+    }
 }

--- a/tests/Formatter/CurlFormatterTest.php
+++ b/tests/Formatter/CurlFormatterTest.php
@@ -2,15 +2,17 @@
 
 use Namshi\Cuzzle\Formatter\CurlFormatter;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Utils;
+use PHPUnit\Framework\TestCase;
 
-class CurlFormatterTest extends \PHPUnit_Framework_TestCase
+class CurlFormatterTest extends TestCase
 {
     /**
      * @var CurlFormatter
      */
     protected $curlFormatter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->curlFormatter = new CurlFormatter();
     }
@@ -69,7 +71,7 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals("curl 'http://example.local?foo=bar'", $curl);
 
-        $body = \GuzzleHttp\Psr7\stream_for(http_build_query(['foo' => 'bar', 'hello' => 'world'], '', '&'));
+        $body = Utils::streamFor(http_build_query(['foo' => 'bar', 'hello' => 'world'], '', '&'));
 
         $request = new Request('GET', 'http://example.local',[],$body);
         $curl    = $this->curlFormatter->format($request);
@@ -80,13 +82,13 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testPOST()
     {
-        $body = \GuzzleHttp\Psr7\stream_for(http_build_query(['foo' => 'bar', 'hello' => 'world'], '', '&'));
+        $body = Utils::streamFor(http_build_query(['foo' => 'bar', 'hello' => 'world'], '', '&'));
 
         $request = new Request('POST', 'http://example.local', [], $body);
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("-d 'foo=bar&hello=world'", $curl);
-        $this->assertNotContains(" -G ", $curl);
+        $this->assertStringContainsString("-d 'foo=bar&hello=world'", $curl);
+        $this->assertStringNotContainsString(" -G ", $curl);
     }
 
     public function testHEAD()
@@ -94,7 +96,7 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
         $request = new Request('HEAD', 'http://example.local');
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("--head", $curl);
+        $this->assertStringContainsString("--head", $curl);
     }
 
     public function testOPTIONS()
@@ -102,7 +104,7 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
         $request = new Request('OPTIONS', 'http://example.local');
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("-X OPTIONS", $curl);
+        $this->assertStringContainsString("-X OPTIONS", $curl);
     }
 
     public function testDELETE()
@@ -110,27 +112,27 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
         $request = new Request('DELETE', 'http://example.local/users/4');
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("-X DELETE", $curl);
+        $this->assertStringContainsString("-X DELETE", $curl);
     }
 
     public function testPUT()
     {
-        $request = new Request('PUT', 'http://example.local', [], \GuzzleHttp\Psr7\stream_for('foo=bar&hello=world'));
+        $request = new Request('PUT', 'http://example.local', [], Utils::streamFor('foo=bar&hello=world'));
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("-d 'foo=bar&hello=world'", $curl);
-        $this->assertContains("-X PUT", $curl);
+        $this->assertStringContainsString("-d 'foo=bar&hello=world'", $curl);
+        $this->assertStringContainsString("-X PUT", $curl);
     }
 
     public function testProperBodyReading()
     {
-        $request = new Request('PUT', 'http://example.local', [], \GuzzleHttp\Psr7\stream_for('foo=bar&hello=world'));
+        $request = new Request('PUT', 'http://example.local', [], Utils::streamFor('foo=bar&hello=world'));
         $request->getBody()->getContents();
 
         $curl    = $this->curlFormatter->format($request);
 
-        $this->assertContains("-d 'foo=bar&hello=world'", $curl);
-        $this->assertContains("-X PUT", $curl);
+        $this->assertStringContainsString("-d 'foo=bar&hello=world'", $curl);
+        $this->assertStringContainsString("-X PUT", $curl);
     }
 
     /**
@@ -140,11 +142,11 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
     {
         // clean input of null bytes
         $body = str_replace(chr(0), '', $body);
-        $request = new Request('POST', 'http://example.local', $headers, \GuzzleHttp\Psr7\stream_for($body));
+        $request = new Request('POST', 'http://example.local', $headers, Utils::streamFor($body));
 
         $curl = $this->curlFormatter->format($request);
 
-        $this->assertContains('foo=bar&hello=world', $curl);
+        $this->assertStringContainsString('foo=bar&hello=world', $curl);
     }
 
     /**
@@ -166,8 +168,9 @@ class CurlFormatterTest extends \PHPUnit_Framework_TestCase
     {
         ini_set('memory_limit', -1);
         $body  = str_repeat('A', 1024*1024*64);
-        $request = new Request('POST', 'http://example.local', [], \GuzzleHttp\Psr7\stream_for($body));
+        $request = new Request('POST', 'http://example.local', [], Utils::streamFor($body));
 
         $curl = $this->curlFormatter->format($request);
+        $this->assertStringContainsString($body, $curl);
     }
 }

--- a/tests/Middleware/CurlFormatterMiddlewareTest.php
+++ b/tests/Middleware/CurlFormatterMiddlewareTest.php
@@ -5,14 +5,15 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Handler\MockHandler;
 use Namshi\Cuzzle\Middleware\CurlFormatterMiddleware;
+use PHPUnit\Framework\TestCase;
 
-class CurlFormatterMiddlewareTest extends \PHPUnit_Framework_TestCase
+class CurlFormatterMiddlewareTest extends TestCase
 {
     public function testGet()
     {
         $mock = new MockHandler([new Response(204)]);
         $handler = HandlerStack::create($mock);
-        $logger = $this->getMock(\Psr\Log\LoggerInterface::class);
+        $logger = $this->getMockForAbstractClass(\Psr\Log\LoggerInterface::class);
 
         $logger
             ->expects($this->once())


### PR DESCRIPTION
PHP's escapeshellarg throws a fatal error on bad input (null bytes, strings that are too long). To workaround this, use symfony/process to escape arguments instead.

Version 3 of symfony/process was used instead of 4 because of Cuzzle's support for PHP 5.5

Solves #20