### PR TITLE
Remove Bad Apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/namshi/cuzzle.svg?branch=master)](https://travis-ci.org/namshi/cuzzle)
 
-This library let's you dump a Guzzle request to a cURL command for debug and log purpose.
+This library lets you dump a Guzzle request to a cURL command for debug and log purpose.
 
 ## Prerequisites
 


### PR DESCRIPTION
The present-tense verb "lets" (as in "allows") doesn't need an apostrophe. (As opposed to the contraction "let's", as in "Let's go!" == "let us go!")