### PR TITLE
Allow guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Get the cURL shell command from a Guzzle request",
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi,

We have recently tagged a new version 7 of guzzle.

https://github.com/guzzle/guzzle/releases/tag/7.0.0

🎉 